### PR TITLE
Fix custom commands

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -16,7 +16,7 @@ services:
       - mongo_db_tests:${MONGO_HOST}
 
   mongo_db_tests:
-    image: 'mongo:4.2.6'
+    image: 'mongo'
     container_name: mongo_db_tests
     ports:
       - '27017:21017'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   mongo_db:
     container_name: ${MONGO_HOST}
-    image: 'mongo:4.2.6'
+    image: 'mongo'
     ports:
       - '27017'
     volumes:

--- a/floppa/models/command.py
+++ b/floppa/models/command.py
@@ -103,12 +103,12 @@ class Command(BaseModel):
         return command, args
 
     @classmethod
-    def extract_command(cls, text: str) -> Command | None:
+    def parse_command(cls, text: str) -> Command | None:
         command, _ = cls.parse(text)
         return command
 
     @classmethod
-    def extract_args(cls, text: str) -> str | None:
+    def parse_args(cls, text: str) -> str | None:
         command, args = cls.parse(text)
         if command is None:
             return None

--- a/floppa/telegram/commands/basic/decide.py
+++ b/floppa/telegram/commands/basic/decide.py
@@ -1,12 +1,13 @@
 from aiogram.types import Message  # type: ignore
 
-from floppa.models import ProtectedCommand
+from floppa.models import Command, ProtectedCommand
 from floppa.telegram import floppa_bot
 from floppa.use_case import DecideUseCase
 
 
 @floppa_bot.dispatcher.message_handler(ProtectedCommand.decide.filter)
 async def decide(message: Message) -> None:
-    use_case = DecideUseCase(message.get_args())
+    options_text = Command.parse_args(message.text)
+    use_case = DecideUseCase(options_text)
     response = await use_case.execute()
     await message.reply(response)

--- a/floppa/telegram/commands/basic/github.py
+++ b/floppa/telegram/commands/basic/github.py
@@ -8,5 +8,8 @@ from floppa.telegram import floppa_bot
 async def github(message: Message) -> None:
     await message.reply(
         "This is my source code:\n"
-        "https://github.com/DOCtorActoAntohich/telegram-floppa-bot"
+        "https://github.com/DOCtorActoAntohich/telegram-floppa-bot\n\n"
+        "You can contribute to this repository!\n"
+        "And maybe suggest features or report bugs by creating a new issue.\n\n"
+        "Let's make flop have no issue!"
     )

--- a/floppa/telegram/commands/custom/del_command.py
+++ b/floppa/telegram/commands/custom/del_command.py
@@ -1,6 +1,6 @@
 from aiogram.types import Message  # type: ignore
 
-from floppa.models import ProtectedCommand
+from floppa.models import Command, ProtectedCommand
 from floppa.telegram import floppa_bot
 from floppa.telegram.command_restrictions import CommandRestriction
 from floppa.use_case import DeleteCommandUseCase
@@ -9,6 +9,7 @@ from floppa.use_case import DeleteCommandUseCase
 @floppa_bot.dispatcher.message_handler(ProtectedCommand.del_command.filter)
 @CommandRestriction.only_for_chat_admins
 async def delete_custom_command(message: Message) -> None:
-    use_case = DeleteCommandUseCase(message.get_args(), message.chat.id)
+    args = Command.parse_args(message.text)
+    use_case = DeleteCommandUseCase(args, message.chat.id)
     response = await use_case.execute()
     await message.reply(response)

--- a/floppa/telegram/commands/custom/set_command.py
+++ b/floppa/telegram/commands/custom/set_command.py
@@ -1,6 +1,6 @@
 from aiogram.types import Message  # type: ignore
 
-from floppa.models import ProtectedCommand
+from floppa.models import Command, ProtectedCommand
 from floppa.telegram import floppa_bot
 from floppa.telegram.command_restrictions import CommandRestriction
 from floppa.use_case import SetCommandUseCase
@@ -9,6 +9,7 @@ from floppa.use_case import SetCommandUseCase
 @floppa_bot.dispatcher.message_handler(ProtectedCommand.set_command.filter)
 @CommandRestriction.only_for_chat_admins
 async def set_custom_command(message: Message) -> None:
-    use_case = SetCommandUseCase(message.get_args(), message.chat.id)
+    args = Command.parse_args(message.text)
+    use_case = SetCommandUseCase(args, message.chat.id)
     response = await use_case.execute()
     await message.reply(response)

--- a/floppa/telegram/commands/general_handler.py
+++ b/floppa/telegram/commands/general_handler.py
@@ -33,8 +33,8 @@ def custom_command_use_case(message: Message) -> ExecuteCustomCommandUseCase | N
     if message_chat_type(message) != ChatType.Group:
         return None
 
-    command = Command(name=message.text)
-    if command.is_malformed():
+    command = Command.parse_command(message.text)
+    if command is None or command.is_malformed():
         return None
 
     return ExecuteCustomCommandUseCase(command, message.chat.id)

--- a/tests/command/test_parse.py
+++ b/tests/command/test_parse.py
@@ -40,10 +40,10 @@ def test_multiline():
 
 
 def test_extract_command():
-    white = Command.extract_command("/WhItE        sPaCe")
-    echo = Command.extract_command("/echo")
-    text = Command.extract_command("text")
-    bad = Command.extract_command("/b[A]d")
+    white = Command.parse_command("/WhItE        sPaCe")
+    echo = Command.parse_command("/echo")
+    text = Command.parse_command("text")
+    bad = Command.parse_command("/b[A]d")
     assert white.name == "white"
     assert echo.name == "echo"
     assert text is None
@@ -51,11 +51,11 @@ def test_extract_command():
 
 
 def test_extract_args():
-    nothing = Command.extract_args("/delete")
-    words = Command.extract_args("/set_command ping @everyone")
-    text = Command.extract_args("plain text")
-    bad = Command.extract_args("/g[oO]d command here")
-    a = Command.extract_args("/c a")  # a
+    nothing = Command.parse_args("/delete")
+    words = Command.parse_args("/set_command ping @everyone")
+    text = Command.parse_args("plain text")
+    bad = Command.parse_args("/g[oO]d command here")
+    a = Command.parse_args("/c a")  # a
     assert nothing is None
     assert words == "ping @everyone"
     assert text is None

--- a/tests/use_case/test_custom_commands.py
+++ b/tests/use_case/test_custom_commands.py
@@ -43,7 +43,7 @@ async def execute_del_command(text: str, chat_id: int) -> DeleteCommandUseCase:
 async def execute_custom_command(
     text: str, chat_id: int
 ) -> tuple[ExecuteCustomCommandUseCase, str | None]:
-    command = Command.extract_command(text)
+    command = Command.parse_command(text)
     assert command is not None
 
     use_case = ExecuteCustomCommandUseCase(command, chat_id)

--- a/tests/use_case/test_custom_commands.py
+++ b/tests/use_case/test_custom_commands.py
@@ -42,9 +42,10 @@ async def execute_del_command(text: str, chat_id: int) -> DeleteCommandUseCase:
 
 async def execute_custom_command(
     text: str, chat_id: int
-) -> tuple[ExecuteCustomCommandUseCase, str | None]:
+) -> tuple[ExecuteCustomCommandUseCase | None, str | None]:
     command = Command.parse_command(text)
-    assert command is not None
+    if command is None:
+        return None, None
 
     use_case = ExecuteCustomCommandUseCase(command, chat_id)
 
@@ -112,7 +113,13 @@ async def test_execute_command_failures(random_ids: list[int]):
 
     message = "/consume"
     use_case, response = await execute_custom_command(message, chat_id)
+    assert use_case is not None
     assert use_case.state == ExecuteCommandUseCaseState.CommandNotFound
+    assert response is None
+
+    message = "no command"
+    use_case, response = await execute_custom_command(message, chat_id)
+    assert use_case is None
     assert response is None
 
 
@@ -139,6 +146,10 @@ async def test_custom_commands(random_ids: list[int]):
     two_executed_b, two_response_b = await execute_custom_command(
         "/goodbye", bad_chat_id
     )
+    assert one_executed is not None
+    assert two_executed is not None
+    assert one_executed_b is not None
+    assert two_executed_b is not None
     assert one_executed.state == ExecuteCommandUseCaseState.Success
     assert two_executed.state == ExecuteCommandUseCaseState.Success
     assert one_executed_b.state == ExecuteCommandUseCaseState.Success
@@ -160,6 +171,8 @@ async def test_custom_commands(random_ids: list[int]):
     two_executed_b, two_response_b = await execute_custom_command(
         "/goodbye", bad_chat_id
     )
+    assert one_executed is not None
+    assert two_executed_b is not None
     assert one_executed.state == ExecuteCommandUseCaseState.Success
     assert two_executed_b.state == ExecuteCommandUseCaseState.Success
     assert one_response == "friend!!"
@@ -167,6 +180,8 @@ async def test_custom_commands(random_ids: list[int]):
 
     two_executed, two_response = await execute_custom_command("/goodbye", good_chat_id)
     one_executed_b, one_response_b = await execute_custom_command("/hello", bad_chat_id)
+    assert two_executed is not None
+    assert one_executed_b is not None
     assert two_executed.state == ExecuteCommandUseCaseState.CommandNotFound
     assert one_executed_b.state == ExecuteCommandUseCaseState.CommandNotFound
     assert two_response is None


### PR DESCRIPTION
This PR fixes #4 so custom commands should now work only with `/` in the beginning.

There's also a couple of code improvements for commands too.